### PR TITLE
feat: upgrade to Node 14

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ resource "aws_lambda_function" "edge" {
   handler          = "index.handler"
   publish          = true
   role             = "${aws_iam_role.edge.arn}"
-  runtime          = "nodejs12.x"
+  runtime          = "nodejs14.x"
   source_code_hash = "${data.archive_file.lambda.output_base64sha256}"
   timeout          = 10
 }


### PR DESCRIPTION
12 is no longer in active LTS, 14 is. Suggesting this move forward so as to support next LTS